### PR TITLE
Added handler for postmap sender_canonical

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,6 +11,12 @@
   command: |
     postmap hash:/etc/postfix/sasl_passwd
 
+- name: postmap sender_canonical
+  tags: postfix
+  become: true
+  command: |
+    postmap hash:/etc/postfix/sender_canonical
+
 - name: restart postfix
   tags: postfix
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,6 +78,7 @@
     owner: root
     group: root
     mode: 0600
+  notify: postmap sender_canonical
   when: postfix_parameters.sender_canonical_maps is defined
 
 - name: Ensure that postfix is started and enabled on boot


### PR DESCRIPTION
Hi there

Thanks for this role!

I think it would be a good idea to add a new handler that run "postmap" on the "sender_canonical" file.
Otherwise, postfix does not work properly.

best